### PR TITLE
Update README.md with missing link to ArgoCD install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Helm Chart: https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm
 
 **Installation**
 
-Install ArgoCD by following the getting started guide here:
+Install ArgoCD by following the getting started guide here: https://argo-cd.readthedocs.io/en/stable/getting_started/
 
 Apply the Trivy-Operator installation manifest:
 


### PR DESCRIPTION
Hi Anais!

Enjoyed the [recent Youtube video](https://youtu.be/KpMtg9h__VM). 

While following along, noticed that the README was missing the link to the ArgoCD getting started guide referenced in video. PR adds the missing link. (Also a heads up: the Youtube video chapters aren't quite accurate (references to GPT/OpenAI))

Cheers!